### PR TITLE
[Seafile] Added ENV variable to enable fastcgi mode on seahub

### DIFF
--- a/seafile/README.md
+++ b/seafile/README.md
@@ -82,3 +82,5 @@ There are some more variables which could be changed but have not been tested an
 
 ### Web server
 This container does not include a web server. It's intended to be run behind a reverse proxy. You can read more about that in the Seafile manual: http://manual.seafile.com/deploy/
+
+If you want to run seahub in fastcgi mode, you can pass ENV variables **SEAFILE_FASTCGI=1** and **SEAFILE_FASTCGI_HOST=0.0.0.0**

--- a/seafile/seafile-entrypoint.sh
+++ b/seafile/seafile-entrypoint.sh
@@ -29,7 +29,12 @@ autorun() {
   then
     exit 1
   fi
-  control_seahub "start"
+  if [ ${SEAFILE_FASTCGI:-} ]
+  then
+    control_seahub "start-fastcgi"
+  else
+    control_seahub "start"
+  fi
   keep_in_foreground
 }
 


### PR DESCRIPTION
It seems that docs from Seafile recommends configuring reverse proxy with fastcgi. (https://manual.seafile.com/deploy/deploy_with_nginx.html)